### PR TITLE
fix : Header 컴포넌트 위치로 인한 next/router 오류

### DIFF
--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -1,7 +1,6 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 import { ServerStyleSheet } from 'styled-components';
 import type { DocumentContext, DocumentInitialProps } from 'next/document';
-import Header from '@/components/Header';
 
 type Props = {
   styles: React.ReactElement[];
@@ -12,7 +11,6 @@ const MyDocument = ({ styles }: Props) => {
     <Html lang="ko">
       <Head>{styles}</Head>
       <body>
-        <Header />
         <Main />
         <NextScript />
       </body>

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -7,6 +7,7 @@ const Home = () => {
       <Head>
         <title>Stack Overflow</title>
       </Head>
+      <Header />
     </>
   );
 };


### PR DESCRIPTION
- _document.tdx파일의 Main 컴포넌트 위에 두었더니 next/router 오류 발생

-  **index.tsx 파일로 이동**