### PR TITLE
Fix/chip 문제 해결

### DIFF
--- a/frontend/components/chip/Chip.test.tsx
+++ b/frontend/components/chip/Chip.test.tsx
@@ -1,16 +1,27 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useRouter } from 'next/router';
 import { Chip } from './Chip';
 
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(() => ({
+    push: jest.fn(),
+  })),
+}));
+
 describe('<Chip/>', () => {
-  beforeEach(() => {});
+  test('chip을 클릭하면 라우터가 이동된다.', () => {
+    const handleClick = jest.fn();
 
-  test('required props로 받아 렌더링 되고, Link 태그를 사용한다.', () => {
+    (useRouter as jest.Mock).mockReturnValue({
+      push: handleClick,
+    });
+
     render(<Chip href="/">react</Chip>);
-    const ins: HTMLAnchorElement = screen.getByText('react');
+    const chip = screen.getByRole('button');
 
-    expect(ins.tagName).toBe('A');
-    expect(ins.href).not.toBeNull();
-    expect(ins).toBeInTheDocument();
+    fireEvent.click(chip);
+
+    expect(handleClick).toBeCalled();
   });
 
   test('props로 watch를 사용시 아이콘이 렌더링 된다', () => {

--- a/frontend/components/chip/Chip.tsx
+++ b/frontend/components/chip/Chip.tsx
@@ -1,6 +1,6 @@
+import { useRouter } from 'next/router';
 import { ReactNode } from 'react';
 import { GoEye } from 'react-icons/go';
-import Link from 'next/link';
 import styled from 'styled-components';
 
 export type ChipProps = {
@@ -10,11 +10,16 @@ export type ChipProps = {
 };
 
 export const Chip = ({ href, watch, children }: ChipProps) => {
+  const router = useRouter();
+
+  const handleChipClick = () => {
+    router.push(href);
+  };
+
   return (
-    <Container href={href}>
+    <Container href={href} onClick={handleChipClick}>
       {watch && (
         <i role="img">
-          {' '}
           <GoEye />
         </i>
       )}
@@ -23,7 +28,7 @@ export const Chip = ({ href, watch, children }: ChipProps) => {
   );
 };
 
-const Container = styled(Link)`
+const Container = styled.button<{ href: string }>`
   display: inline-flex;
   padding: 5px 6px;
   width: fit-content;


### PR DESCRIPTION
에러 조치
chip을 Link 컴포너트로 생성하면 jest에서 오류가 발생했다
이유 - chip의 용도를 생각하면 조상 태그 중 Link 컴포넌트를 무조건 사용중이기 때문이다

+ 테스트 코드 추가
useRouter().push() 를 하였을 경우 jest에서는 mocking이 필요하다
useRouter 훅에 대한 mocking 후 hook 호출 여부를 확인하는 테스트 코드 추가 완료